### PR TITLE
Fix a bug with the update mode where successive builds on the same branch won't update

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -29,18 +29,17 @@ if [ -e "/bazooka-key" ]; then
   chmod 0600 /bazooka-key
 fi
 
-if [ -z "$UPDATE" ]; then
-  echo "performing a fresh checkout"
-  git clone "$BZK_SCM_URL" --recursive /bazooka
-else
-  echo "performing an update"
-  pushd /bazooka
-  git clean -fd
-  git fetch
-  popd
-fi
-
 pushd /bazooka
-  git checkout "$BZK_SCM_REFERENCE"
+  if [ -z "$UPDATE" ]; then
+    echo "performing a fresh checkout"
+    git clone "$BZK_SCM_URL" --recursive .
+    git checkout "$BZK_SCM_REFERENCE"
+  else
+    echo "performing an update"
+    git clean -fd
+    git fetch
+    git reset --hard "$BZK_SCM_REFERENCE"
+  fi
+  
   extract_meta
 popd


### PR DESCRIPTION
To reproduce the bug:
- activate scm reuse
- build using a branch name as an scm ref
- add a new commit on the said branch
- rebuild using the same branch name as an scm ref

The build will use the previous version and the last commit won't be included.

This fix uses the atomic weapon, i.e. `reset --hard` to make sure the passed revision is checked out no matter what.
