### PR TITLE
Use alpine for smaller image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
-FROM debian:jessie
+FROM alpine:3.1
 
-RUN apt-get update \
-	&& apt-get install -y git \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apk --update add git openssh bash perl
 
 ADD run.sh /run.sh
 RUN echo "    IdentityFile /bazooka-key" >> /etc/ssh/ssh_config


### PR DESCRIPTION
- git for the git command
- openssh for the ssh client
- bash to run the script run.sh
- perl because of failure in git if not present 

```
[bazooka/scm-git] Cloning into '/bazooka'...
[bazooka/scm-git] /usr/libexec/git-core/git-submodule: line 1: /usr/bin/perl: not found
[bazooka/scm-git] /usr/libexec/git-core/git-submodule: line 1: /usr/bin/perl: not found
[bazooka/scm-git] /bazooka /
```

before

```
> docker images
REPOSITORY              TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
bazooka/scm-git         latest              e221df79f280        8 days ago          209.9 MB
```

```
> docker images
REPOSITORY              TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
bazooka/scm-git         latest              18c6dbd32d8c        13 minutes ago      69.12 MB
```
